### PR TITLE
feat: scaffold monitoring frontend

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+dist
+.playwright-report

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,17 @@
+# YCXT Frontend
+
+基于 React + Vite 构建的监控大屏前端，内置路由、状态管理、实时数据服务对接与端到端交互测试样例。
+
+## 开发命令
+
+```bash
+npm install
+npm run dev
+```
+
+## 构建与测试
+
+```bash
+npm run build
+npm run test:e2e
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>YCXT Monitoring Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "ycxt-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "axios": "^1.6.8",
+    "echarts": "^5.5.0",
+    "echarts-for-react": "^3.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "zustand": "^4.4.1",
+    "socket.io-client": "^4.7.5"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.42.1",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "^18.2.22",
+    "@typescript-eslint/eslint-plugin": "^7.2.0",
+    "@typescript-eslint/parser": "^7.2.0",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.4",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  retries: 0,
+  reporter: [['list'], ['html', { outputFolder: '.playwright-report' }]],
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    trace: 'on-first-retry'
+  },
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    }
+  ]
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,29 @@
+import { Suspense, useEffect } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import Navigation from './components/Navigation';
+import { useDataStore } from './state/dataStore';
+import DashboardPage from './pages/DashboardPage';
+import MessagesPage from './pages/MessagesPage';
+
+const App = () => {
+  const teardown = useDataStore((state) => state.teardown);
+
+  useEffect(() => () => teardown(), [teardown]);
+
+  return (
+    <div className="app-shell">
+      <Navigation />
+      <main className="app-main">
+        <Suspense fallback={<div className="loading">Loading...</div>}>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/messages" element={<MessagesPage />} />
+          </Routes>
+        </Suspense>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/components/DeviceStatusCard.tsx
+++ b/frontend/src/components/DeviceStatusCard.tsx
@@ -1,0 +1,37 @@
+import type { DeviceStatus } from '../state/types';
+
+interface Props {
+  device: DeviceStatus;
+}
+
+const statusClassMap: Record<DeviceStatus['health'], string> = {
+  online: 'status-online',
+  warning: 'status-warning',
+  offline: 'status-offline'
+};
+
+const DeviceStatusCard = ({ device }: Props) => {
+  return (
+    <div className={`device-card ${statusClassMap[device.health]}`}>
+      <header className="device-card__header">
+        <h3>{device.name}</h3>
+        <span className="device-card__tag">{device.health.toUpperCase()}</span>
+      </header>
+      <p className="device-card__metric">
+        <span>CPU</span>
+        <strong>{device.metrics.cpu}%</strong>
+      </p>
+      <p className="device-card__metric">
+        <span>内存</span>
+        <strong>{device.metrics.memory}%</strong>
+      </p>
+      <p className="device-card__metric">
+        <span>网络</span>
+        <strong>{device.metrics.network} Mbps</strong>
+      </p>
+      <footer className="device-card__footer">最近心跳：{new Date(device.lastHeartbeat).toLocaleTimeString()}</footer>
+    </div>
+  );
+};
+
+export default DeviceStatusCard;

--- a/frontend/src/components/MessageTable.tsx
+++ b/frontend/src/components/MessageTable.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../state/dataStore';
+
+const MessageTable = () => {
+  const messages = useDataStore((state) => state.messages);
+
+  const rows = useMemo(
+    () =>
+      messages.map((message) => (
+        <tr key={message.id}>
+          <td>{message.id}</td>
+          <td>{message.deviceName}</td>
+          <td>{message.payload}</td>
+          <td>{message.status}</td>
+          <td>{new Date(message.timestamp).toLocaleString()}</td>
+        </tr>
+      )),
+    [messages]
+  );
+
+  return (
+    <div className="card">
+      <div className="card-header">
+        <h2>实时报文</h2>
+        <span className="card-subtitle">来自最新数据通道的消息流</span>
+      </div>
+      <div className="table-wrapper">
+        <table className="message-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>设备</th>
+              <th>内容</th>
+              <th>状态</th>
+              <th>时间</th>
+            </tr>
+          </thead>
+          <tbody>{rows}</tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default MessageTable;

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -1,0 +1,19 @@
+import { NavLink } from 'react-router-dom';
+
+const Navigation = () => {
+  return (
+    <nav className="app-nav">
+      <h1 className="app-logo">YCXT 控制面板</h1>
+      <div className="app-links">
+        <NavLink to="/dashboard" className={({ isActive }) => (isActive ? 'active' : '')}>
+          大屏总览
+        </NavLink>
+        <NavLink to="/messages" className={({ isActive }) => (isActive ? 'active' : '')}>
+          报文监控
+        </NavLink>
+      </div>
+    </nav>
+  );
+};
+
+export default Navigation;

--- a/frontend/src/components/PredictionHint.tsx
+++ b/frontend/src/components/PredictionHint.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { useDataStore } from '../state/dataStore';
+
+const PredictionHint = () => {
+  const insights = useDataStore((state) => state.predictions);
+
+  const topInsight = useMemo(() => insights[0], [insights]);
+  const rest = useMemo(() => insights.slice(1), [insights]);
+
+  return (
+    <div className="card prediction-card">
+      <div className="card-header">
+        <h2>智能预测提示</h2>
+        <span className="card-subtitle">模型实时检测到的风险事件</span>
+      </div>
+      {topInsight ? (
+        <div className="prediction-card__highlight">
+          <strong>{topInsight.title}</strong>
+          <p>{topInsight.description}</p>
+          <span className="prediction-card__confidence">置信度：{Math.round(topInsight.confidence * 100)}%</span>
+        </div>
+      ) : (
+        <p>暂无风险，系统运行平稳。</p>
+      )}
+      {rest.length > 0 && (
+        <ul className="prediction-card__list">
+          {rest.map((item) => (
+            <li key={item.id}>
+              <strong>{item.title}</strong>
+              <span>{Math.round(item.confidence * 100)}%</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default PredictionHint;

--- a/frontend/src/components/VisualizationPanel.tsx
+++ b/frontend/src/components/VisualizationPanel.tsx
@@ -1,0 +1,62 @@
+import ReactEcharts from 'echarts-for-react';
+import { useMemo } from 'react';
+import { useDataStore } from '../state/dataStore';
+
+const VisualizationPanel = () => {
+  const trend = useDataStore((state) => state.metricsTrend);
+
+  const option = useMemo(() => {
+    return {
+      backgroundColor: 'transparent',
+      tooltip: { trigger: 'axis' },
+      legend: { data: ['CPU', 'Memory', 'Network'], textStyle: { color: '#eee' } },
+      grid: { left: 40, right: 20, bottom: 30, top: 40 },
+      xAxis: {
+        type: 'category',
+        boundaryGap: false,
+        data: trend.map((item) => new Date(item.timestamp).toLocaleTimeString()),
+        axisLine: { lineStyle: { color: '#555' } },
+        axisLabel: { color: '#aaa' }
+      },
+      yAxis: {
+        type: 'value',
+        axisLine: { lineStyle: { color: '#555' } },
+        splitLine: { lineStyle: { color: 'rgba(255,255,255,0.05)' } },
+        axisLabel: { color: '#aaa' }
+      },
+      series: [
+        {
+          name: 'CPU',
+          type: 'line',
+          areaStyle: {},
+          smooth: true,
+          data: trend.map((item) => item.cpu)
+        },
+        {
+          name: 'Memory',
+          type: 'line',
+          smooth: true,
+          data: trend.map((item) => item.memory)
+        },
+        {
+          name: 'Network',
+          type: 'line',
+          smooth: true,
+          data: trend.map((item) => item.network)
+        }
+      ]
+    };
+  }, [trend]);
+
+  return (
+    <div className="card visualization-card">
+      <div className="card-header">
+        <h2>大屏可视化面板</h2>
+        <span className="card-subtitle">关键指标实时曲线</span>
+      </div>
+      <ReactEcharts option={option} style={{ height: 360 }} notMerge lazyUpdate />
+    </div>
+  );
+};
+
+export default VisualizationPanel;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import DeviceStatusCard from '../components/DeviceStatusCard';
+import PredictionHint from '../components/PredictionHint';
+import VisualizationPanel from '../components/VisualizationPanel';
+import { useDataStore } from '../state/dataStore';
+
+const DashboardPage = () => {
+  const devices = useDataStore((state) => state.devices);
+  const bootstrap = useDataStore((state) => state.bootstrap);
+
+  useEffect(() => {
+    bootstrap();
+  }, [bootstrap]);
+
+  return (
+    <div className="grid dashboard-grid">
+      <section className="grid-span-2">
+        <VisualizationPanel />
+      </section>
+      <section className="grid-span-1">
+        <PredictionHint />
+      </section>
+      <section className="grid-span-3 device-grid">
+        {devices.map((device) => (
+          <DeviceStatusCard key={device.id} device={device} />
+        ))}
+      </section>
+    </div>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/pages/MessagesPage.tsx
+++ b/frontend/src/pages/MessagesPage.tsx
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import MessageTable from '../components/MessageTable';
+import { useDataStore } from '../state/dataStore';
+
+const MessagesPage = () => {
+  const bootstrap = useDataStore((state) => state.bootstrap);
+
+  useEffect(() => {
+    bootstrap();
+  }, [bootstrap]);
+
+  return (
+    <div className="messages-page">
+      <MessageTable />
+    </div>
+  );
+};
+
+export default MessagesPage;

--- a/frontend/src/services/basApi.ts
+++ b/frontend/src/services/basApi.ts
@@ -1,0 +1,134 @@
+import axios from 'axios';
+import { io, Socket } from 'socket.io-client';
+import type { DeviceStatus, Message, PredictionInsight, TrendPoint } from '../state/types';
+
+type SnapshotResponse = {
+  messages: Message[];
+  devices: DeviceStatus[];
+  predictions: PredictionInsight[];
+  metricsTrend: TrendPoint[];
+};
+
+type RealtimePayload = {
+  message: Message;
+  devices: DeviceStatus[];
+  predictions: PredictionInsight[];
+  trendPoint: TrendPoint;
+};
+
+let socket: Socket | null = null;
+
+const api = axios.create({
+  baseURL: '/api',
+  timeout: 10_000
+});
+
+const fallbackSnapshot: SnapshotResponse = {
+  messages: Array.from({ length: 10 }).map((_, idx) => ({
+    id: `MSG-${idx + 1}`,
+    deviceName: `传感器-${(idx % 4) + 1}`,
+    payload: `温度:${20 + idx}°C 湿度:${50 + idx}%`,
+    status: idx % 3 === 0 ? '错误' : idx % 2 === 0 ? '延迟' : '正常',
+    timestamp: Date.now() - idx * 60_000
+  })),
+  devices: Array.from({ length: 6 }).map((_, idx) => ({
+    id: `DEV-${idx + 1}`,
+    name: `边缘节点-${idx + 1}`,
+    health: idx % 4 === 0 ? 'warning' : idx % 5 === 0 ? 'offline' : 'online',
+    metrics: {
+      cpu: 45 + (idx % 4) * 10,
+      memory: 38 + (idx % 5) * 8,
+      network: 120 + (idx % 3) * 25
+    },
+    lastHeartbeat: Date.now() - idx * 25_000
+  })),
+  predictions: [
+    {
+      id: 'pred-1',
+      title: '冷却水压即将低于阈值',
+      description: '冷却水路持续波动，建议检查泵和阀门。',
+      confidence: 0.86
+    },
+    {
+      id: 'pred-2',
+      title: '风机震动增长',
+      description: '近期震动指标上升，需关注轴承磨损。',
+      confidence: 0.63
+    },
+    {
+      id: 'pred-3',
+      title: '通信延迟偶发',
+      description: '局部链路负载偏高，建议优化网络策略。',
+      confidence: 0.51
+    }
+  ],
+  metricsTrend: Array.from({ length: 20 }).map((_, idx) => ({
+    timestamp: Date.now() - (19 - idx) * 60_000,
+    cpu: 40 + Math.sin(idx / 2) * 15,
+    memory: 55 + Math.cos(idx / 3) * 8,
+    network: 100 + Math.sin(idx / 4) * 30
+  }))
+};
+
+export async function fetchDashboardSnapshot(): Promise<SnapshotResponse> {
+  try {
+    const { data } = await api.get<SnapshotResponse>('/dashboard');
+    return data;
+  } catch (error) {
+    console.warn('使用模拟快照数据，因为后端暂不可达。');
+    return fallbackSnapshot;
+  }
+}
+
+export function subscribeRealtime(onData: (payload: RealtimePayload) => void): (() => void) | undefined {
+  if (socket) {
+    socket.off('dashboard:update');
+  }
+
+  try {
+    socket = io('/ws', { autoConnect: true });
+    socket.on('dashboard:update', onData);
+    return () => {
+      socket?.off('dashboard:update', onData);
+    };
+  } catch (error) {
+    console.warn('WebSocket 连接失败，启动本地模拟。', error);
+    let tick = 0;
+    const interval = setInterval(() => {
+      tick += 1;
+      const trendPoint: TrendPoint = {
+        timestamp: Date.now(),
+        cpu: 55 + Math.sin(tick / 2) * 10,
+        memory: 60 + Math.cos(tick / 3) * 6,
+        network: 110 + Math.sin(tick / 4) * 25
+      };
+      const message: Message = {
+        id: `SIM-${Date.now()}`,
+        deviceName: `传感器-${(tick % 5) + 1}`,
+        payload: `温度:${(Math.random() * 10 + 20).toFixed(1)}°C`,
+        status: '正常',
+        timestamp: Date.now()
+      };
+      onData({
+        message,
+        devices: fallbackSnapshot.devices,
+        predictions: fallbackSnapshot.predictions,
+        trendPoint
+      });
+    }, 5_000);
+
+    return () => clearInterval(interval);
+  }
+  return undefined;
+}
+
+export function disconnectRealtime() {
+  if (socket) {
+    socket.disconnect();
+    socket = null;
+  }
+}
+
+export async function sendControlCommand(deviceId: string, command: string) {
+  await api.post(`/devices/${deviceId}/commands`, { command });
+}

--- a/frontend/src/state/dataStore.ts
+++ b/frontend/src/state/dataStore.ts
@@ -1,0 +1,72 @@
+let realtimeCleanup: (() => void) | undefined;
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { disconnectRealtime, fetchDashboardSnapshot, subscribeRealtime } from '../services/basApi';
+import type { DeviceStatus, Message, PredictionInsight, TrendPoint } from './types';
+
+interface DataState {
+  loading: boolean;
+  messages: Message[];
+  devices: DeviceStatus[];
+  predictions: PredictionInsight[];
+  metricsTrend: TrendPoint[];
+  bootstrap: () => Promise<void>;
+  teardown: () => void;
+}
+
+export const useDataStore = create<DataState>()(
+  persist<DataState>(
+    (set, get) => ({
+      loading: false,
+      messages: [],
+      devices: [],
+      predictions: [],
+      metricsTrend: [],
+      bootstrap: async () => {
+        if (get().loading) return;
+        set({ loading: true });
+        try {
+          const snapshot = await fetchDashboardSnapshot();
+          set({
+            loading: false,
+            messages: snapshot.messages,
+            devices: snapshot.devices,
+            predictions: snapshot.predictions,
+            metricsTrend: snapshot.metricsTrend
+          });
+          realtimeCleanup?.();
+          const cleanup = subscribeRealtime((payload) => {
+            set((state) => ({
+              messages: [payload.message, ...state.messages].slice(0, 50),
+              devices: payload.devices,
+              predictions: payload.predictions,
+              metricsTrend: [...state.metricsTrend.slice(-19), payload.trendPoint]
+            }));
+          });
+          if (typeof cleanup === 'function') {
+            realtimeCleanup = cleanup;
+          }
+        } catch (error) {
+          console.error('Failed to bootstrap data', error);
+          set({ loading: false });
+        }
+      },
+      teardown: () => {
+        realtimeCleanup?.();
+        realtimeCleanup = undefined;
+        disconnectRealtime();
+        set({ loading: false });
+      }
+    }),
+    {
+      name: 'ycxt-data-cache',
+      partialize: (state) => ({
+        messages: state.messages,
+        devices: state.devices,
+        predictions: state.predictions,
+        metricsTrend: state.metricsTrend
+      })
+    }
+  )
+);

--- a/frontend/src/state/types.ts
+++ b/frontend/src/state/types.ts
@@ -1,0 +1,35 @@
+export interface Message {
+  id: string;
+  deviceName: string;
+  payload: string;
+  status: '正常' | '延迟' | '错误';
+  timestamp: number;
+}
+
+export type DeviceHealth = 'online' | 'warning' | 'offline';
+
+export interface DeviceStatus {
+  id: string;
+  name: string;
+  health: DeviceHealth;
+  metrics: {
+    cpu: number;
+    memory: number;
+    network: number;
+  };
+  lastHeartbeat: number;
+}
+
+export interface PredictionInsight {
+  id: string;
+  title: string;
+  description: string;
+  confidence: number;
+}
+
+export interface TrendPoint {
+  timestamp: number;
+  cpu: number;
+  memory: number;
+  network: number;
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,227 @@
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, #1f2933, #111827 60%);
+  color: #f3f4f6;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  min-height: 100vh;
+}
+
+body {
+  background: transparent;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+  background: rgba(17, 24, 39, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.app-logo {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.app-links a {
+  color: #9ca3af;
+  margin-left: 1.5rem;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.app-links a.active {
+  color: #60a5fa;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem;
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.dashboard-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-span-1 {
+  grid-column: span 1;
+}
+
+.grid-span-2 {
+  grid-column: span 2;
+}
+
+.grid-span-3 {
+  grid-column: span 3;
+}
+
+@media (max-width: 960px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+  .grid-span-2,
+  .grid-span-3 {
+    grid-column: span 1;
+  }
+}
+
+.card {
+  background: rgba(30, 41, 59, 0.8);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 20px 35px -25px rgba(56, 189, 248, 0.5);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 1rem;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.card-subtitle {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.message-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.message-table th,
+.message-table td {
+  text-align: left;
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.device-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.device-card {
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.9);
+}
+
+.device-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.device-card__tag {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+}
+
+.device-card__metric {
+  display: flex;
+  justify-content: space-between;
+  margin: 0.25rem 0;
+  color: #e5e7eb;
+}
+
+.device-card__footer {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.status-online {
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.status-warning {
+  border-color: rgba(250, 204, 21, 0.5);
+}
+
+.status-offline {
+  border-color: rgba(248, 113, 113, 0.5);
+}
+
+.prediction-card__highlight {
+  padding: 1rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2), rgba(59, 130, 246, 0.05));
+  margin-bottom: 1rem;
+}
+
+.prediction-card__confidence {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: #93c5fd;
+  font-size: 0.85rem;
+}
+
+.prediction-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.prediction-card__list li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  color: #cbd5f5;
+}
+
+.visualization-card {
+  min-height: 380px;
+}
+
+.messages-page {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tests/core.spec.ts
+++ b/frontend/tests/core.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('监控大屏核心流程', () => {
+  test('导航与可视化渲染', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'YCXT 控制面板' })).toBeVisible();
+
+    await page.getByRole('link', { name: '大屏总览' }).click();
+    await expect(page.getByRole('heading', { name: '大屏可视化面板' })).toBeVisible();
+    await expect(page.getByText('智能预测提示')).toBeVisible();
+  });
+
+  test('报文表格展示', async ({ page }) => {
+    await page.goto('/messages');
+    await expect(page.getByRole('heading', { name: '实时报文' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '设备' })).toBeVisible();
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "playwright.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React frontend with routing, Zustand state, and themed styling for the monitoring dashboard
- implement dashboard, message table, device cards, prediction hints, and visualization components wired to REST/WebSocket services with mock fallbacks
- add Playwright end-to-end smoke tests and project configuration for building and previewing the UI

## Testing
- not run (dependencies not installed)

------
https://chatgpt.com/codex/tasks/task_e_68dbadc89048832fad40b15095614cd6